### PR TITLE
fix(search): return correct note page after searching for it

### DIFF
--- a/www/js/controllers/controllers.js
+++ b/www/js/controllers/controllers.js
@@ -31,6 +31,12 @@ angular.module('starter.controllers', [])
     });
   }
 
+// open the provided notes page, this solves the search filter issue
+  $scope.openNote = function(note) {
+    var index = $scope.notes.indexOf(note);
+    $window.location.href = "#/app/notes/" + index;
+  }
+
   //*******************************************************
   //*******************************************************
   //**********NEW NOTE MODAL*******************************

--- a/www/js/controllers/controllers.js
+++ b/www/js/controllers/controllers.js
@@ -24,6 +24,13 @@ angular.module('starter.controllers', [])
   //on Page load get the tasks
   onpageLoad();
 
+  // on pull down, refresh by fetching the tasks from the server
+  $scope.fetchOnPullToRefresh = function() {
+    return getTasks(function() {
+      $scope.$broadcast('scroll.refreshComplete');
+    });
+  }
+
   //*******************************************************
   //*******************************************************
   //**********NEW NOTE MODAL*******************************
@@ -339,7 +346,7 @@ angular.module('starter.controllers', [])
   //*******************************************************
 
   //retrieves tasks
-  function getTasks(){
+  function getTasks(cb){
     Task.get(
       {
         "token": $scope.token
@@ -347,6 +354,9 @@ angular.module('starter.controllers', [])
       function(response){
         $scope.notes = response;
         toast("Successfully Synced Notes with the Server");
+        if(cb) {
+          cb();
+        }
       },
       function(err){
         switch(err){

--- a/www/templates/archives.html
+++ b/www/templates/archives.html
@@ -8,7 +8,7 @@
       </label>
     </div>
     <ion-list>
-      <ion-item ng-repeat="note in notes | orderBy: '-date' | filter: searchText" href="#/app/notes/{{$index}}" ng-show="note.archive">
+      <ion-item ng-repeat="note in notes | orderBy: '-date' | filter: searchText" ng-click="openNote(note)" ng-show="note.archive">
         {{note.title}}
         <div class="date-notes-menu">{{formatDate(note.date)}}</div>
       </ion-item>

--- a/www/templates/archives.html
+++ b/www/templates/archives.html
@@ -1,5 +1,6 @@
 <ion-view view-title="Archived Notes">
   <ion-content>
+    <ion-refresher pulling-text="Pull to refresh..." on-refresh="fetchOnPullToRefresh()"></ion-refresher>
     <div class="list list-inset">
       <label class="item item-input">
         <i class="icon ion-search placeholder-icon"></i>

--- a/www/templates/archives.html
+++ b/www/templates/archives.html
@@ -7,7 +7,7 @@
       </label>
     </div>
     <ion-list>
-      <ion-item ng-repeat="note in notes | filter: searchText" href="#/app/notes/{{$index}}" ng-show="note.archive">
+      <ion-item ng-repeat="note in notes | orderBy: '-date' | filter: searchText" href="#/app/notes/{{$index}}" ng-show="note.archive">
         {{note.title}}
         <div class="date-notes-menu">{{formatDate(note.date)}}</div>
       </ion-item>

--- a/www/templates/notes.html
+++ b/www/templates/notes.html
@@ -10,7 +10,7 @@
     <button class="button button-block button-positive button-radius-none" ng-show="!notes" ng-click="login()" type="submit">Login</button>
     <button class="button button-block button-positive button-radius-none" ng-show="!notes" ng-click="register()" type="submit">Register</button>
   <ion-list>
-    <ion-item ng-repeat="note in notes | filter: searchText" href="#/app/notes/{{$index}}" ng-show="!note.archive">
+    <ion-item ng-repeat="note in notes | orderBy: '-date' | filter: searchText" href="#/app/notes/{{$index}}" ng-show="!note.archive">
       {{note.title}}
       <div class="date-notes-menu">{{formatDate(note.date)}}</div>
     </ion-item>

--- a/www/templates/notes.html
+++ b/www/templates/notes.html
@@ -1,5 +1,6 @@
 <ion-view view-title="Notes">
   <ion-content>
+    <ion-refresher pulling-text="Pull to refresh..." on-refresh="fetchOnPullToRefresh()"></ion-refresher>
     <div class="list list-inset" ng-show="notes">
       <label class="item item-input">
         <i class="icon ion-search placeholder-icon"></i>
@@ -9,6 +10,10 @@
     <p class="large-title hello-message" ng-show="!notes">Welcome to Nota! Please login or register.</p>
     <button class="button button-block button-positive button-radius-none" ng-show="!notes" ng-click="login()" type="submit">Login</button>
     <button class="button button-block button-positive button-radius-none" ng-show="!notes" ng-click="register()" type="submit">Register</button>
+  <!-- <ion-refresher
+      pulling-text="Pull to refresh..."
+      on-refresh="loadOnPullToRefresh()">
+  <ion-refresher> -->
   <ion-list>
     <ion-item ng-repeat="note in notes | orderBy: '-date' | filter: searchText" href="#/app/notes/{{$index}}" ng-show="!note.archive">
       {{note.title}}

--- a/www/templates/notes.html
+++ b/www/templates/notes.html
@@ -10,10 +10,6 @@
     <p class="large-title hello-message" ng-show="!notes">Welcome to Nota! Please login or register.</p>
     <button class="button button-block button-positive button-radius-none" ng-show="!notes" ng-click="login()" type="submit">Login</button>
     <button class="button button-block button-positive button-radius-none" ng-show="!notes" ng-click="register()" type="submit">Register</button>
-  <!-- <ion-refresher
-      pulling-text="Pull to refresh..."
-      on-refresh="loadOnPullToRefresh()">
-  <ion-refresher> -->
   <ion-list>
     <ion-item ng-repeat="note in notes | orderBy: '-date' | filter: searchText" href="#/app/notes/{{$index}}" ng-show="!note.archive">
       {{note.title}}

--- a/www/templates/notes.html
+++ b/www/templates/notes.html
@@ -11,7 +11,7 @@
     <button class="button button-block button-positive button-radius-none" ng-show="!notes" ng-click="login()" type="submit">Login</button>
     <button class="button button-block button-positive button-radius-none" ng-show="!notes" ng-click="register()" type="submit">Register</button>
   <ion-list>
-    <ion-item ng-repeat="note in notes | orderBy: '-date' | filter: searchText" href="#/app/notes/{{$index}}" ng-show="!note.archive">
+    <ion-item ng-repeat="note in notes | orderBy: '-date' | filter: searchText" ng-click="openNote(note)" ng-show="!note.archive">
       {{note.title}}
       <div class="date-notes-menu">{{formatDate(note.date)}}</div>
     </ion-item>


### PR DESCRIPTION
### What does this PR do?

This PR fixes the issue where searching a note and clicking on it takes you to an incorrect note. Also, allow the notes be listed from latest to oldest.

This PR is related to issue #26 
close #26 
close #27 